### PR TITLE
Added NotUsedInSortBy for DISABLE_ATTRIBUTE_HIERACHIES

### DIFF
--- a/src/standard/Metadata/DISABLE_ATTRIBUTE_HIERACHIES.json
+++ b/src/standard/Metadata/DISABLE_ATTRIBUTE_HIERACHIES.json
@@ -5,7 +5,7 @@
   "Description": "Disable Attribute hierarchies for hidden collumns. This will ensure faster processing.",
   "Severity": 2,
   "Scope": "DataColumn",
-  "Expression": "not IsVisible\nand IsAvailableInMDX\nand not UsedInHierarchies.Any()\nand not UsedInVariations.Any()",
+  "Expression": "not IsVisible\nand IsAvailableInMDX\nand not UsedInHierarchies.Any()\nand not UsedInVariations.Any()\nand not UsedInSortBy.Any()",
   "FixExpression": "IsAvailableInMDX = false",
   "CompatibilityLevel": 1400
 }


### PR DESCRIPTION
I found out that when you apply the fix for DISABLE_ATTRIBUTE_HIERACHIES that if a column is used for Sorting and the property is IsAvailableInMDX = false it will not deploy.